### PR TITLE
Adds redux-logger to the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-router-dom": "4.2.2",
     "redux": "4.0.0",
     "redux-thunk": "2.2.0",
+    "redux-logger": "^3.0.6",
     "sass-loader": "6.0.6",
     "style-loader": "^0.21.0",
     "url-loader": "^1.0.1",

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -2,16 +2,23 @@ import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import trainingResourcesReducer from '../reducers/trainingResources';
 import filtersReducer from '../reducers/filters';
 import thunk from 'redux-thunk';
+import logger from 'redux-logger';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 export default () => {
+
+  let middleware = [ thunk ]
+  console.log(process.env.NODE_ENV)
+  if (process.env.NODE_ENV !== 'production') {
+    middleware = [ ...middleware, logger ]
+  }
   const store = createStore(
     combineReducers({
       trainingResources: trainingResourcesReducer,
-      filters: filtersReducer 
+      filters: filtersReducer
     }),
-    composeEnhancers(applyMiddleware(thunk))
+    composeEnhancers(applyMiddleware(...middleware))
   );
 
   return store;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const webpack = require('webpack')
+const DefinePlugin = webpack.DefinePlugin
 
 module.exports = (env) => {
   const isProduction = env === 'production';
@@ -32,6 +34,13 @@ module.exports = (env) => {
     devServer: {
       contentBase: path.join(__dirname, 'public'),
       historyApiFallback: true
-    }
+    },
+    plugins: [
+      new DefinePlugin({
+        'process.env': {
+          'NODE_ENV': JSON.stringify(env)
+        }
+      })
+    ]
   };
 };


### PR DESCRIPTION
Need to figure out why the NODE_ENV doesn’t get set… might be the way web pack is working?

I've added this - if you look at the console you'll see a really nice view of what actions are doing to your state.

If we configure webpack correctly this can be turned off in production - if you look at the way I've created the store

I tried to amend the webpack config to set this variable... but I'm not sure env is pulled through in the webpack config atm